### PR TITLE
Improve config security and error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,14 @@ The project relies on the following external Python libraries:
 *   **backtester**: Used for backtesting trading strategies.
 
 These dependencies are listed in the `requirements.txt` file.
+
+## Configuration
+
+Set your Binance API credentials using environment variables before running the bot:
+
+```bash
+export API_KEY="your_api_key"
+export SECRET_KEY="your_secret_key"
+```
+
+The provided `config.json` keeps these values empty to avoid accidentally committing secrets.

--- a/config.json
+++ b/config.json
@@ -1,6 +1,6 @@
 {
-    "api_key": "your_api_key",
-    "secret_key": "your_secret_key",
+    "api_key": "",
+    "secret_key": "",
     "trade_symbol": "BTCUSDT",
     "data_interval": "1m"
 }

--- a/configuration_service.py
+++ b/configuration_service.py
@@ -1,8 +1,7 @@
 import json
-from typing import List, Dict, Callable
+import os
+from typing import List, Dict, Callable, Type, Any
 from utils import handle_error
-
-from typing import Type, Any
 
 class ConfigurationService:
     @handle_error
@@ -52,6 +51,10 @@ class TypedConfigurationService(ConfigurationService):
 
     @handle_error
     def get_config(self, key: str, default=None):
+        env_key = key.upper()
+        env_value = os.getenv(env_key)
+        if env_value is not None:
+            return env_value
         return self.config.get(key, default)
 
     @handle_error
@@ -63,7 +66,6 @@ class TypedConfigurationService(ConfigurationService):
     def register_observer(self, observer: Callable):
         self.observers.append(observer)
 
-    @handle_error
     @handle_error
     def unregister_observer(self, observer: Callable):
         self.observers.remove(observer)

--- a/data_feed.py
+++ b/data_feed.py
@@ -2,6 +2,7 @@ import logging
 from binance.client import Client
 import pandas as pd
 from config import get_config
+from exceptions import BaseTradingException, DataError
 
 logger = logging.getLogger(__name__)
 
@@ -47,8 +48,9 @@ class DataFeed:
             klines = self.client.get_klines(symbol=self.symbol, interval=self.interval)
         except Exception as e:
             logger.error(f"An error occurred: {e}", exc_info=True)
-            raise DataError(f"An error occurred: {e}") from e
-            raise DataRetrievalError(f"Could not retrieve data for symbol {self.symbol} and interval {self.interval}") from e
+            raise DataRetrievalError(
+                f"Could not retrieve data for symbol {self.symbol} and interval {self.interval}"
+            ) from e
 
         data = pd.DataFrame(klines, columns=['timestamp', 'open', 'high', 'low', 'close', 'volume', 'close_time', 'quote_asset_volume', 'trades', 'taker_buy_base', 'taker_buy_quote', 'ignored'])
         data = data.astype(float)

--- a/tests/test_configuration_service_env.py
+++ b/tests/test_configuration_service_env.py
@@ -1,0 +1,10 @@
+import os
+from configuration_service import TypedConfigurationService
+
+
+def test_env_overrides_config(monkeypatch):
+    monkeypatch.setenv("API_KEY", "env_key")
+    service = TypedConfigurationService('config.json')
+    service.declare_config('api_key', str, '')
+    assert service.get_config('api_key') == 'env_key'
+    monkeypatch.delenv("API_KEY")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,16 @@
+import logging
+import pytest
+from utils import handle_error
+from exceptions import BaseTradingException
+
+
+@handle_error
+def faulty_function():
+    raise ValueError("boom")
+
+
+def test_handle_error_raises_custom_exception(caplog):
+    caplog.set_level(logging.ERROR)
+    with pytest.raises(BaseTradingException):
+        faulty_function()
+    assert any("Error in faulty_function" in record.message for record in caplog.records)

--- a/utils.py
+++ b/utils.py
@@ -1,18 +1,21 @@
 import logging
 import functools
+from exceptions import BaseTradingException
 
 logger = logging.getLogger(__name__)
 
+
 def handle_error(func):
-    """
-    Decorator to handle exceptions in strategy methods.
-    """
+    """Decorator to log errors and raise a BaseTradingException."""
+    
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
         try:
             return func(*args, **kwargs)
         except Exception as e:
-            logger.error(f"An error occurred in {func.__name__}: {e}", exc_info=True)
-            raise BaseTradingException(f"An error occurred in {func.__name__}: {e}") from e
-            return None
+            log = logging.getLogger(func.__module__)
+            log.error(f"Error in {func.__name__}: {e}", exc_info=True)
+            raise BaseTradingException(f"Error in {func.__name__}: {e}") from e
+
     return wrapper
+


### PR DESCRIPTION
## Summary
- add environment variable override support in `ConfigurationService`
- avoid storing API secrets in `config.json`
- update README with environment variable instructions
- clean up `handle_error` decorator
- fix import and error handling in `DataFeed`
- add regression tests for new behaviour

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'strategy_factory')*

------
https://chatgpt.com/codex/tasks/task_e_6845d0e0d8c083228466be28444df9ea