### PR TITLE
Add IntelligentRedisCache with async support

### DIFF
--- a/src/cache/__init__.py
+++ b/src/cache/__init__.py
@@ -1,0 +1,3 @@
+from .redis_cache_manager import IntelligentRedisCache, cache_function
+
+__all__ = ["IntelligentRedisCache", "cache_function"]

--- a/src/cache/redis_cache_manager.py
+++ b/src/cache/redis_cache_manager.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import os
+import pickle
+import time
+import zlib
+from io import BytesIO
+from typing import Any, Awaitable, Callable, Iterable
+
+import numpy as np
+import redis.asyncio as aioredis
+
+
+class CacheError(Exception):
+    """Base class for cache errors."""
+
+
+class CircuitBreakerOpen(CacheError):
+    """Raised when the circuit breaker is open."""
+
+
+def _serialize(obj: Any) -> bytes:
+    buf = BytesIO()
+    if isinstance(obj, np.ndarray):
+        np.save(buf, obj, allow_pickle=False)
+        marker = b"n"
+    else:
+        buf.write(pickle.dumps(obj, protocol=pickle.HIGHEST_PROTOCOL))
+        marker = b"p"
+    payload = marker + buf.getvalue()
+    if len(payload) > 1024:
+        return b"1" + zlib.compress(payload)
+    return b"0" + payload
+
+
+def _deserialize(raw: bytes) -> Any:
+    if not raw:
+        return None
+    flag, payload = raw[0:1], raw[1:]
+    if flag == b"1":
+        payload = zlib.decompress(payload)
+    marker, data = payload[0:1], payload[1:]
+    if marker == b"n":
+        return np.load(BytesIO(data), allow_pickle=False)
+    return pickle.loads(data)
+
+
+def _hash(params: Any) -> str:
+    try:
+        encoded = json.dumps(params, sort_keys=True, default=str).encode()
+    except TypeError:
+        encoded = pickle.dumps(params)
+    return hashlib.sha256(encoded).hexdigest()
+
+
+class IntelligentRedisCache:
+    """Advanced Redis cache with compression and fault tolerance."""
+
+    def __init__(
+        self,
+        host: str | None = None,
+        port: int | None = None,
+        db: int | None = None,
+        failure_threshold: int = 3,
+        open_timeout: int = 30,
+    ) -> None:
+        self.client = aioredis.Redis(
+            host=host or os.getenv("REDIS_HOST", "localhost"),
+            port=int(port or os.getenv("REDIS_PORT", "6379")),
+            db=int(db or os.getenv("REDIS_DB", "0")),
+        )
+        self.failure_threshold = failure_threshold
+        self.open_timeout = open_timeout
+        self._failures = 0
+        self._open_until = 0.0
+        self.hits = 0
+        self.misses = 0
+
+    def _is_open(self) -> bool:
+        return time.time() < self._open_until
+
+    async def _record_failure(self) -> None:
+        self._failures += 1
+        if self._failures >= self.failure_threshold:
+            self._open_until = time.time() + self.open_timeout
+            self._failures = 0
+
+    def build_key(self, namespace: str, params: Any) -> str:
+        return f"{namespace}:{_hash(params)}"
+
+    async def get(self, namespace: str, params: Any) -> Any | None:
+        if self._is_open():
+            raise CircuitBreakerOpen("cache unavailable")
+        key = self.build_key(namespace, params)
+        try:
+            raw = await asyncio.wait_for(self.client.get(key), timeout=1.0)
+            if raw is None:
+                self.misses += 1
+                return None
+            self.hits += 1
+            return _deserialize(raw)
+        except Exception:
+            await self._record_failure()
+            return None
+
+    async def set(self, namespace: str, params: Any, value: Any, ttl: int) -> None:
+        if self._is_open():
+            return
+        key = self.build_key(namespace, params)
+        try:
+            payload = _serialize(value)
+            await asyncio.wait_for(self.client.setex(key, ttl, payload), timeout=1.0)
+        except Exception:
+            await self._record_failure()
+
+    async def invalidate(self, prefix: str) -> None:
+        if self._is_open():
+            return
+        try:
+            keys = await asyncio.wait_for(self.client.keys(f"{prefix}*"), timeout=1.0)
+            if keys:
+                await self.client.delete(*keys)
+        except Exception:
+            await self._record_failure()
+
+    def hit_ratio(self) -> float:
+        total = self.hits + self.misses
+        return (self.hits / total) if total else 0.0
+
+    async def warm_cache(
+        self,
+        tasks: Iterable[tuple[str, Callable[..., Awaitable[Any]], tuple, dict, int]],
+    ) -> None:
+        for ns, func, args, kwargs, ttl in tasks:
+            result = await func(*args, **kwargs)
+            await self.set(ns, {"args": args, "kwargs": kwargs}, result, ttl)
+
+
+F = Callable[..., Awaitable[Any]]
+_default_cache = IntelligentRedisCache()
+
+
+def cache_function(namespace: str, ttl: int = 300) -> Callable[[F], F]:
+    def decorator(func: F) -> F:
+        async def wrapper(*args: Any, **kwargs: Any) -> Any:
+            params = {"args": args, "kwargs": kwargs}
+            cached = await _default_cache.get(namespace, params)
+            if cached is not None:
+                return cached
+            result = await func(*args, **kwargs)
+            await _default_cache.set(namespace, params, result, ttl)
+            return result
+
+        return wrapper  # type: ignore[return-value]
+
+    return decorator

--- a/src/data/market_data_feed.py
+++ b/src/data/market_data_feed.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import logging
+import os
+from typing import Any
+
+import pandas as pd
+from binance.client import Client
+
+from ..cache import IntelligentRedisCache
+from config import get_config
+from performance_utils import log_memory_usage
+from utils import handle_error
+from exceptions import DataRetrievalError, DataError
+
+logger = logging.getLogger(__name__)
+
+
+class MarketDataFeed:
+    """Data feed with Redis caching and checksums."""
+
+    def __init__(
+        self,
+        client: Client,
+        symbol: str | None = None,
+        interval: str | None = None,
+        cache: IntelligentRedisCache | None = None,
+    ) -> None:
+        from config import BINANCE_CONSTANTS
+
+        self.client = client
+        self.symbol = symbol or get_config("default_symbol")
+        self.interval = interval or BINANCE_CONSTANTS["KLINE_INTERVAL_15MINUTE"]
+        self.max_rows = int(os.getenv("DATAFRAME_MAX_ROWS", "1000"))
+        self.cache = cache or IntelligentRedisCache()
+        logger.info("Initialized MarketDataFeed %s %s", self.symbol, self.interval)
+
+    async def _fetch_klines(self) -> list[Any]:
+        try:
+            return await asyncio.to_thread(
+                self.client.get_klines, symbol=self.symbol, interval=self.interval
+            )
+        except Exception as exc:
+            logger.warning("Data retrieval failed: %s", exc)
+            raise DataRetrievalError("Failed to fetch klines") from exc
+
+    def _prepare_dataframe(self, klines: list[Any]) -> pd.DataFrame:
+        data = pd.DataFrame(
+            klines,
+            columns=[
+                "timestamp",
+                "open",
+                "high",
+                "low",
+                "close",
+                "volume",
+                "close_time",
+                "quote_asset_volume",
+                "trades",
+                "taker_buy_base",
+                "taker_buy_quote",
+                "ignored",
+            ],
+        )
+        data = data.astype(float)
+        data.fillna(method="ffill", inplace=True)
+        return data.head(self.max_rows)
+
+    def _checksum(self, data: list[Any]) -> str:
+        return hashlib.sha256(str(data).encode()).hexdigest()
+
+    @handle_error
+    async def get_data(self) -> pd.DataFrame:
+        params = {"symbol": self.symbol, "interval": self.interval}
+        cached = await self.cache.get("market", params)
+        if cached is not None:
+            return cached
+        klines = await self._fetch_klines()
+        df = self._prepare_dataframe(klines)
+        await self.cache.set("market", params | {"cs": self._checksum(klines)}, df, 300)
+        log_memory_usage("MarketDataFeed: ")
+        return df

--- a/src/indicators/numba_indicators.py
+++ b/src/indicators/numba_indicators.py
@@ -11,6 +11,8 @@ from typing import Tuple
 from numpy.typing import NDArray
 from typing import cast
 
+from ..cache import cache_function
+
 import numpy as np
 from numba import jit, prange  # type: ignore
 
@@ -111,24 +113,41 @@ def calculate_macd(data: NDArray[np.float64], fast: int = 12, slow: int = 26, si
 class NumbaIndicatorEngine:
     """Async wrapper for Numba-accelerated indicators."""
 
+    @cache_function("sma")
     async def sma(self, data: NDArray[np.float64], window: int) -> NDArray[np.float64]:
         _validate_1d(data, "data")
         return cast(NDArray[np.float64], calculate_sma(data, window))
 
+    @cache_function("ema")
     async def ema(self, data: NDArray[np.float64], window: int) -> NDArray[np.float64]:
         _validate_1d(data, "data")
         return cast(NDArray[np.float64], calculate_ema(data, window))
 
+    @cache_function("rsi")
     async def rsi(self, data: NDArray[np.float64], window: int) -> NDArray[np.float64]:
         _validate_1d(data, "data")
         return cast(NDArray[np.float64], calculate_rsi(data, window))
 
-    async def atr(self, high: NDArray[np.float64], low: NDArray[np.float64], close: NDArray[np.float64], window: int) -> NDArray[np.float64]:
+    @cache_function("atr")
+    async def atr(
+        self,
+        high: NDArray[np.float64],
+        low: NDArray[np.float64],
+        close: NDArray[np.float64],
+        window: int,
+    ) -> NDArray[np.float64]:
         _validate_1d(high, "high")
         _validate_1d(low, "low")
         _validate_1d(close, "close")
         return cast(NDArray[np.float64], calculate_atr(high, low, close, window))
 
-    async def macd(self, data: NDArray[np.float64], fast: int = 12, slow: int = 26, signal: int = 9) -> Tuple[NDArray[np.float64], NDArray[np.float64]]:
+    @cache_function("macd")
+    async def macd(
+        self,
+        data: NDArray[np.float64],
+        fast: int = 12,
+        slow: int = 26,
+        signal: int = 9,
+    ) -> Tuple[NDArray[np.float64], NDArray[np.float64]]:
         _validate_1d(data, "data")
         return cast(Tuple[NDArray[np.float64], NDArray[np.float64]], calculate_macd(data, fast, slow, signal))

--- a/tests/test_database_async.py
+++ b/tests/test_database_async.py
@@ -15,8 +15,15 @@ class DummyPool:
     def __init__(self) -> None:
         self.connection = DummyConn()
 
-    async def acquire(self):
-        return self.connection
+    def acquire(self):
+        class _CM:
+            async def __aenter__(self_inner):
+                return self.connection
+
+            async def __aexit__(self_inner, exc_type, exc, tb):
+                return False
+
+        return _CM()
 
     async def release(self, conn):
         pass

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -16,7 +16,8 @@ class DummyStrategy(BaseStrategy):
         pass
 
     def run(self):
-        return pd.DataFrame({"close": [100, 110], "signal": [0, 1], "position": [0, 1]})
+        index = pd.date_range("2020-01-01", periods=2, freq="D")
+        return pd.DataFrame({"close": [100, 110], "signal": [0, 1], "position": [0, 1]}, index=index)
 
     def open_position(self, side: str, price: float, size: float):
         self.position_manager.open_position(self.symbol, side, price, size)
@@ -38,5 +39,11 @@ async def test_full_workflow(monkeypatch):
 
     strategy = DummyStrategy()
     analyzer = PerformanceAnalyzer()
+    from service.service_locator import ServiceLocator
+    class DummyMetricsService:
+        async def insert_performance_metrics(self, **kwargs):
+            return None
+
+    ServiceLocator().register("PerformanceMetricsService", DummyMetricsService())
     results = await analyzer.calculate_performance(strategy.run())
     assert "metrics" in results

--- a/tests/test_numba_indicators.py
+++ b/tests/test_numba_indicators.py
@@ -1,6 +1,9 @@
 import numpy as np
 import pandas as pd
 import pytest
+import fakeredis
+
+from src.cache.redis_cache_manager import _default_cache
 
 from src.indicators.numba_indicators import (
     NumbaIndicatorEngine,
@@ -10,6 +13,13 @@ from src.indicators.numba_indicators import (
     calculate_atr,
     calculate_macd,
 )
+
+
+@pytest.fixture(autouse=True)
+def fake_cache(monkeypatch):
+    fake = fakeredis.aioredis.FakeRedis()
+    monkeypatch.setattr(_default_cache, "client", fake)
+    yield
 
 
 @pytest.fixture

--- a/tests/test_redis_cache_manager.py
+++ b/tests/test_redis_cache_manager.py
@@ -1,0 +1,55 @@
+import asyncio
+import numpy as np
+import fakeredis
+import pytest
+
+from src.cache.redis_cache_manager import IntelligentRedisCache, _default_cache
+from src.indicators.numba_indicators import NumbaIndicatorEngine
+
+
+@pytest.fixture(autouse=True)
+def fake_redis(monkeypatch):
+    fake = fakeredis.aioredis.FakeRedis()
+    monkeypatch.setattr(_default_cache, "client", fake)
+    yield
+
+
+@pytest.mark.asyncio
+async def test_cache_set_get_numpy():
+    cache = IntelligentRedisCache()
+    cache.client = fakeredis.aioredis.FakeRedis()
+    arr = np.arange(1000, dtype=np.float64)
+    await cache.set("arr", {"n": 1}, arr, 10)
+    res = await cache.get("arr", {"n": 1})
+    assert np.array_equal(arr, res)
+
+
+@pytest.mark.asyncio
+async def test_invalidate_and_ratio():
+    cache = IntelligentRedisCache()
+    cache.client = fakeredis.aioredis.FakeRedis()
+    await cache.set("x", {"a": 1}, 5, 10)
+    assert await cache.get("x", {"a": 1}) == 5
+    assert cache.hit_ratio() == 1.0
+    await cache.invalidate("x")
+    assert await cache.get("x", {"a": 1}) is None
+
+
+@pytest.mark.asyncio
+async def test_concurrent_indicator_cache(monkeypatch):
+    fake = fakeredis.aioredis.FakeRedis()
+    monkeypatch.setattr(_default_cache, "client", fake)
+    engine = NumbaIndicatorEngine()
+    data = np.random.rand(20).astype(np.float64)
+
+    await engine.sma(data, 5)
+    _default_cache.hits = 0
+    _default_cache.misses = 0
+
+    async def run():
+        await engine.sma(data, 5)
+
+    tasks = [run() for _ in range(1000)]
+    await asyncio.gather(*tasks)
+    assert _default_cache.hit_ratio() > 0.9
+


### PR DESCRIPTION
## Summary
- implement `IntelligentRedisCache` for async Redis caching with compression and circuit breaking
- create `MarketDataFeed` using the new cache
- cache indicator results using decorator
- add async caching tests and update existing tests
- ensure test suite passes with pytest-asyncio

## Testing
- `pytest -q`
- `mypy src/ --strict` *(fails: Found 38 errors)*
- `bandit -r src/ -q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68465c432fb88322b04099543e9d3a18