### PR TITLE
Add monitoring stack with Prometheus and health checks

### DIFF
--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -1,0 +1,21 @@
+version: '3.9'
+services:
+  prometheus:
+    image: prom/prometheus:latest
+    volumes:
+      - ./docker/prometheus.yml:/etc/prometheus/prometheus.yml
+    ports:
+      - "9090:9090"
+
+  grafana:
+    image: grafana/grafana:latest
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+
+  jaeger:
+    image: jaegertracing/all-in-one:1.57
+    ports:
+      - "16686:16686"
+      - "6831:6831/udp"

--- a/docker/prometheus.yml
+++ b/docker/prometheus.yml
@@ -1,0 +1,6 @@
+global:
+  scrape_interval: 15s
+scrape_configs:
+  - job_name: 'trading_bot'
+    static_configs:
+      - targets: ['app:8080']

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ pandas==2.2.3  # Pinned version
 psycopg2_binary==2.9.10
 asyncpg==0.29.0
 pytest==8.3.5
+pytest-asyncio==0.23.6
 python_binance==1.0.28  # Pinned version
 ta==0.11.0  # Pinned version
 redis==5.0.4
@@ -13,3 +14,9 @@ fakeredis==2.23.2
 pydantic==2.7.1
 mypy==1.10.0
 numba==0.61.2  # Pinned version
+prometheus_client==0.20.0
+aiohttp==3.9.5
+opentelemetry-api==1.21.0
+opentelemetry-sdk==1.21.0
+opentelemetry-exporter-jaeger==1.21.0
+sentry-sdk==2.1.0

--- a/src/monitoring/__init__.py
+++ b/src/monitoring/__init__.py
@@ -1,0 +1,17 @@
+from .observability import (
+    start_metrics_server,
+    setup_tracing,
+    setup_sentry,
+    record_system_metrics,
+)
+from .health_checks import HealthServer
+from .performance_tracking import PerformanceTracker
+
+__all__ = [
+    "start_metrics_server",
+    "setup_tracing",
+    "setup_sentry",
+    "record_system_metrics",
+    "HealthServer",
+    "PerformanceTracker",
+]

--- a/src/monitoring/health_checks.py
+++ b/src/monitoring/health_checks.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from aiohttp import web
+from pydantic import BaseModel, ValidationError, field_validator
+
+
+class HealthServerError(Exception):
+    """Raised when the health server encounters an error."""
+
+
+class _PortModel(BaseModel):
+    port: int
+
+    @field_validator("port")
+    @classmethod
+    def _validate_port(cls, v: int) -> int:
+        if not 1 <= v <= 65535:
+            raise ValueError("port out of range")
+        return v
+
+
+class HealthServer:
+    def __init__(self, port: int = 8000) -> None:
+        try:
+            self.config = _PortModel(port=port)
+        except ValidationError as exc:
+            raise HealthServerError(str(exc))
+        self._app = web.Application()
+        self._app.router.add_get("/healthz", self._health)
+        self._app.router.add_get("/readyz", self._ready)
+        self.runner: web.AppRunner | None = None
+
+    async def _health(self, _: web.Request) -> web.Response:
+        return web.Response(text="ok")
+
+    async def _ready(self, _: web.Request) -> web.Response:
+        return web.Response(text="ready")
+
+    async def start(self) -> None:
+        self.runner = web.AppRunner(self._app)
+        await self.runner.setup()
+        site = web.TCPSite(self.runner, "0.0.0.0", self.config.port)
+        try:
+            await site.start()
+        except Exception as exc:  # pragma: no cover - cannot easily trigger
+            raise HealthServerError("failed to start") from exc
+
+    async def stop(self) -> None:
+        if self.runner:
+            await self.runner.cleanup()

--- a/src/monitoring/observability.py
+++ b/src/monitoring/observability.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import asyncio
+import os
+
+import psutil
+from prometheus_client import Counter, Gauge, Histogram, start_http_server
+from opentelemetry import trace
+from opentelemetry.exporter.jaeger.thrift import JaegerExporter
+from opentelemetry.sdk.resources import SERVICE_NAME, Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+import sentry_sdk
+
+
+class MonitoringSetupError(Exception):
+    """Raised when monitoring initialization fails."""
+
+
+ORDERS_TOTAL = Counter("orders_total", "Total orders", ["strategy"])
+SLIPPAGE_HIST = Histogram(
+    "slippage_histogram", "Order slippage", ["strategy"], buckets=(0.0, 0.1, 0.2, 0.5, 1.0)
+)
+PORTFOLIO_VALUE = Gauge("portfolio_value_gauge", "Portfolio value", ["account"])
+CPU_USAGE = Gauge("cpu_usage", "CPU usage percentage")
+MEMORY_USAGE = Gauge("memory_usage", "Memory usage percentage")
+ERROR_COUNTER = Counter("error_total", "Application errors", ["type"])
+LATENCY_HIST = Histogram(
+    "latency_distribution", "Request latency", buckets=(0.01, 0.1, 0.5, 1, 2)
+)
+PNL_GAUGE = Gauge("pnl", "Profit and loss", ["account"])
+RISK_EXPOSURE = Gauge("risk_exposure", "Current risk exposure", ["account"])
+MARKET_DATA_LATENCY = Histogram(
+    "market_data_latency", "Market data latency", buckets=(0.01, 0.05, 0.1, 0.5)
+)
+
+
+async def start_metrics_server(port: int = 8080) -> None:
+    """Start Prometheus metrics server."""
+    try:
+        await asyncio.to_thread(start_http_server, port)
+    except Exception as exc:  # pragma: no cover - rarely triggered
+        raise MonitoringSetupError("Prometheus failed") from exc
+
+
+def setup_tracing(service: str) -> None:
+    """Configure Jaeger tracing."""
+    try:
+        exporter = JaegerExporter(hostname=os.getenv("JAEGER_HOST", "localhost"))
+        provider = TracerProvider(
+            resource=Resource.create({SERVICE_NAME: service})
+        )
+        provider.add_span_processor(BatchSpanProcessor(exporter))
+        trace.set_tracer_provider(provider)
+    except Exception as exc:  # pragma: no cover - rarely triggered
+        raise MonitoringSetupError("Tracing setup failed") from exc
+
+
+def setup_sentry() -> None:
+    """Initialize Sentry if DSN provided."""
+    dsn = os.getenv("SENTRY_DSN")
+    if not dsn:
+        return
+    try:
+        sentry_sdk.init(dsn=dsn, traces_sample_rate=1.0)
+    except Exception as exc:  # pragma: no cover - rarely triggered
+        raise MonitoringSetupError("Sentry setup failed") from exc
+
+
+async def record_system_metrics() -> None:
+    """Update CPU and memory metrics."""
+    CPU_USAGE.set(psutil.cpu_percent())
+    MEMORY_USAGE.set(psutil.virtual_memory().percent)

--- a/src/monitoring/performance_tracking.py
+++ b/src/monitoring/performance_tracking.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from .observability import (
+    ORDERS_TOTAL,
+    SLIPPAGE_HIST,
+    PORTFOLIO_VALUE,
+    PNL_GAUGE,
+    RISK_EXPOSURE,
+    MARKET_DATA_LATENCY,
+)
+
+
+class PerformanceTracker:
+    """Track trading performance metrics."""
+
+    @staticmethod
+    async def record_order(strategy: str) -> None:
+        ORDERS_TOTAL.labels(strategy=strategy).inc()
+
+    @staticmethod
+    async def record_slippage(strategy: str, value: float) -> None:
+        SLIPPAGE_HIST.labels(strategy=strategy).observe(value)
+
+    @staticmethod
+    async def set_portfolio_value(account: str, value: float) -> None:
+        PORTFOLIO_VALUE.labels(account=account).set(value)
+
+    @staticmethod
+    async def record_pnl(account: str, value: float) -> None:
+        PNL_GAUGE.labels(account=account).set(value)
+
+    @staticmethod
+    async def set_risk(account: str, value: float) -> None:
+        RISK_EXPOSURE.labels(account=account).set(value)
+
+    @staticmethod
+    async def record_market_latency(value: float) -> None:
+        MARKET_DATA_LATENCY.observe(value)

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -1,0 +1,42 @@
+import asyncio
+
+import aiohttp
+import pytest
+from prometheus_client import REGISTRY
+
+from src.monitoring.health_checks import HealthServer
+from src.monitoring.observability import (
+    ORDERS_TOTAL,
+    SLIPPAGE_HIST,
+    PORTFOLIO_VALUE,
+    PNL_GAUGE,
+)
+from src.monitoring.performance_tracking import PerformanceTracker
+
+
+@pytest.mark.asyncio
+async def test_performance_metrics_update() -> None:
+    await PerformanceTracker.record_order("s1")
+    await PerformanceTracker.record_slippage("s1", 0.1)
+    await PerformanceTracker.set_portfolio_value("acc", 100.0)
+    await PerformanceTracker.record_pnl("acc", 5.0)
+
+    assert ORDERS_TOTAL.labels(strategy="s1")._value.get() == 1
+    count = REGISTRY.get_sample_value(
+        "slippage_histogram_count", {"strategy": "s1"}
+    )
+    assert count == 1
+    assert PORTFOLIO_VALUE.labels(account="acc")._value.get() == 100.0
+    assert PNL_GAUGE.labels(account="acc")._value.get() == 5.0
+
+
+@pytest.mark.asyncio
+async def test_health_server() -> None:
+    server = HealthServer(port=8081)
+    await server.start()
+
+    async with aiohttp.ClientSession() as session:
+        async with session.get("http://localhost:8081/healthz") as resp:
+            assert resp.status == 200
+            assert await resp.text() == "ok"
+    await server.stop()


### PR DESCRIPTION
## Summary
- add observability modules for Prometheus, Jaeger and Sentry
- implement Kubernetes-ready health server
- track trading performance metrics
- provide docker compose for monitoring stack
- include tests for monitoring utilities

## Testing
- `pytest tests/test_monitoring.py -q`
- `pytest tests/ --cov=src/ --cov-report=html` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `mypy src/ --strict` *(fails: found 54 errors)*
- `bandit -r src/`
- `python scripts/benchmark.py` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68466472f2fc8322a6f9e7e49207a395