### PR TITLE
Implement financial validator

### DIFF
--- a/src/validation/financial_validator.py
+++ b/src/validation/financial_validator.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal, ROUND_DOWN
+from enum import Enum
+import logging
+import re
+from typing import Dict, Any, Union, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class ValidationError(Exception):
+    """Custom exception for validation failures"""
+
+
+class RiskLimitType(Enum):
+    POSITION_SIZE = "position_size"
+    ORDER_VALUE = "order_value"
+    DAILY_VOLUME = "daily_volume"
+    LEVERAGE = "leverage"
+
+
+@dataclass
+class TradingLimits:
+    max_position_size_usd: Decimal
+    max_order_value_usd: Decimal
+    max_daily_volume_usd: Decimal
+    max_leverage: Decimal
+    min_order_size_usd: Decimal
+    symbol_limits: Dict[str, Dict[str, Decimal]]
+    max_open_positions: int
+    max_concentration_pct: Decimal
+
+
+class FinancialValidator:
+    def __init__(self, trading_limits: TradingLimits):
+        self.limits = trading_limits
+        self.decimal_places = 8
+        self._symbol_regex = re.compile(r"^[A-Z0-9]{6,12}$")
+
+    def _to_decimal(self, value: Union[str, float, Decimal]) -> Decimal:
+        return Decimal(str(value)).quantize(Decimal(10) ** -self.decimal_places)
+
+    def validate_price(self, price: Union[str, float, Decimal], symbol: str,
+                       current_market_price: Decimal) -> Decimal:
+        try:
+            price_dec = self._to_decimal(price)
+            if price_dec <= 0:
+                raise ValidationError("Price must be positive")
+            limits = self.limits.symbol_limits.get(symbol, {})
+            tick = limits.get("tick_size", Decimal("0.00000001"))
+            if (price_dec % tick) != 0:
+                raise ValidationError(f"Price not aligned with tick size {tick}")
+            max_dev = limits.get("max_deviation_pct", Decimal("0.05"))
+            if current_market_price > 0 and abs(price_dec - current_market_price) > current_market_price * max_dev:
+                raise ValidationError("Price deviates from market price too much")
+            return price_dec
+        except Exception as exc:  # noqa: BLE001
+            logger.error("Price validation failed: %s", exc)
+            raise
+
+    def validate_quantity(self, quantity: Union[str, float, Decimal], symbol: str,
+                          current_portfolio_value: Decimal) -> Decimal:
+        try:
+            qty = self._to_decimal(quantity)
+            if qty <= 0:
+                raise ValidationError("Quantity must be positive")
+            sym_limits = self.limits.symbol_limits.get(symbol, {})
+            min_usd = sym_limits.get("min_qty_usd", self.limits.min_order_size_usd)
+            ref_price = sym_limits.get("reference_price", Decimal("0"))
+            order_value = qty * ref_price
+            if ref_price > 0 and order_value < min_usd:
+                raise ValidationError("Order value below minimum size")
+            if ref_price > 0 and order_value > self.limits.max_position_size_usd:
+                raise ValidationError("Order value exceeds max position size")
+            if current_portfolio_value > 0 and order_value > current_portfolio_value * self.limits.max_concentration_pct:
+                raise ValidationError("Position concentration limit breached")
+            return qty
+        except Exception as exc:  # noqa: BLE001
+            logger.error("Quantity validation failed: %s", exc)
+            raise
+
+    def validate_order_value(self, price: Decimal, quantity: Decimal, side: str,
+                             symbol: str) -> bool:
+        try:
+            value = (price * quantity).quantize(Decimal(10) ** -self.decimal_places)
+            if value > self.limits.max_order_value_usd:
+                raise ValidationError("Order value exceeds limit")
+            # Daily volume and leverage checks can be added here
+            return True
+        except Exception as exc:  # noqa: BLE001
+            logger.error("Order value validation failed: %s", exc)
+            raise
+
+    def validate_symbol(self, symbol: str) -> str:
+        if not self._symbol_regex.match(symbol):
+            logger.error("Symbol format invalid: %s", symbol)
+            raise ValidationError("Invalid symbol format")
+        if symbol not in self.limits.symbol_limits:
+            logger.error("Symbol not allowed: %s", symbol)
+            raise ValidationError("Symbol not allowed")
+        return symbol
+
+    def validate_trading_parameters(self, params: Dict[str, Any]) -> Dict[str, Decimal]:
+        symbol = self.validate_symbol(params["symbol"])
+        price = self.validate_price(params["price"], symbol, params.get("market_price", Decimal("0")))
+        quantity = self.validate_quantity(params["quantity"], symbol, params.get("portfolio_value", Decimal("0")))
+        self.validate_order_value(price, quantity, params.get("side", "buy"), symbol)
+        return {"symbol": symbol, "price": price, "quantity": quantity}
+
+    def check_risk_limits(self, order_data: Dict[str, Any], current_positions: Dict[str, Decimal],
+                          account_balance: Decimal) -> Dict[str, bool]:
+        try:
+            total_exposure = sum(current_positions.values()) + order_data["price"] * order_data["quantity"]
+            breached = total_exposure > account_balance * self.limits.max_leverage
+            return {"leverage_limit": not breached}
+        except Exception as exc:  # noqa: BLE001
+            logger.error("Risk limit check failed: %s", exc)
+            raise

--- a/tests/test_financial_validator.py
+++ b/tests/test_financial_validator.py
@@ -1,0 +1,47 @@
+import pytest
+from decimal import Decimal
+from src.validation.financial_validator import (
+    FinancialValidator,
+    TradingLimits,
+    ValidationError,
+)
+
+LIMITS = TradingLimits(
+    max_position_size_usd=Decimal("100000"),
+    max_order_value_usd=Decimal("1000000"),
+    max_daily_volume_usd=Decimal("5000000"),
+    max_leverage=Decimal("5"),
+    min_order_size_usd=Decimal("10"),
+    symbol_limits={
+        "BTCUSDT": {
+            "tick_size": Decimal("0.01"),
+            "min_qty_usd": Decimal("10"),
+            "reference_price": Decimal("30000"),
+            "max_deviation_pct": Decimal("0.05"),
+        }
+    },
+    max_open_positions=10,
+    max_concentration_pct=Decimal("0.1"),
+)
+
+validator = FinancialValidator(LIMITS)
+
+
+def test_validate_price_success():
+    price = validator.validate_price(30000, "BTCUSDT", Decimal("30010"))
+    assert isinstance(price, Decimal)
+
+
+def test_validate_price_deviation():
+    with pytest.raises(ValidationError):
+        validator.validate_price(32000, "BTCUSDT", Decimal("30000"))
+
+
+def test_validate_quantity_bounds():
+    qty = validator.validate_quantity(0.001, "BTCUSDT", Decimal("200000"))
+    assert qty == Decimal("0.00100000")
+
+
+def test_validate_quantity_exceeds_position():
+    with pytest.raises(ValidationError):
+        validator.validate_quantity(10, "BTCUSDT", Decimal("1000"))

--- a/validation.py
+++ b/validation.py
@@ -1,41 +1,60 @@
+from decimal import Decimal
 from typing import Iterable
+from src.validation.financial_validator import (
+    FinancialValidator,
+    TradingLimits,
+    ValidationError,
+)
 
-ALLOWED_INTERVALS = {
-    '1m', '3m', '5m', '15m', '30m', '1h'
+ALLOWED_INTERVALS: set[str] = {"1m", "3m", "5m", "15m", "30m", "1h"}
+
+# Example symbol-specific limits; in production these should come from config
+_SYMBOL_LIMITS = {
+    "BTCUSDT": {"tick_size": Decimal("0.01"), "min_qty_usd": Decimal("10"), "reference_price": Decimal("30000"), "max_deviation_pct": Decimal("0.05")},
+    "ETHUSDT": {"tick_size": Decimal("0.01"), "min_qty_usd": Decimal("10"), "reference_price": Decimal("2000"), "max_deviation_pct": Decimal("0.05")},
 }
+
+_DEFAULT_LIMITS = TradingLimits(
+    max_position_size_usd=Decimal("100000"),
+    max_order_value_usd=Decimal("1000000"),
+    max_daily_volume_usd=Decimal("5000000"),
+    max_leverage=Decimal("5"),
+    min_order_size_usd=Decimal("10"),
+    symbol_limits=_SYMBOL_LIMITS,
+    max_open_positions=10,
+    max_concentration_pct=Decimal("0.1"),
+)
+
+_validator = FinancialValidator(_DEFAULT_LIMITS)
 
 
 def validate_symbol(symbol: str) -> str:
-    if not symbol or not isinstance(symbol, str):
-        raise ValueError("Symbol must be a non-empty string")
-    if not symbol.endswith(("USDT", "BTC", "ETH")):
-        raise ValueError("Invalid trading pair")
-    return symbol.upper()
+    return _validator.validate_symbol(symbol)
 
 
-def validate_quantity(quantity: float) -> float:
-    if not isinstance(quantity, (int, float)):
-        raise ValueError("Quantity must be a number")
-    if quantity <= 0:
-        raise ValueError("Quantity must be positive")
-    return float(quantity)
+def validate_quantity(quantity: float, symbol: str = "BTCUSDT", portfolio_value: float = 0.0) -> float:
+    qty = _validator.validate_quantity(quantity, symbol, Decimal(str(portfolio_value)))
+    return float(qty)
+
+
+def validate_price(price: float, symbol: str, market_price: float) -> float:
+    pr = _validator.validate_price(price, symbol, Decimal(str(market_price)))
+    return float(pr)
 
 
 def validate_timeframe(interval: str) -> str:
     if interval not in ALLOWED_INTERVALS:
-        raise ValueError(f"Invalid timeframe: {interval}")
+        raise ValidationError(f"Invalid timeframe: {interval}")
     return interval
 
 
 def validate_risk(value: float) -> float:
-    if not isinstance(value, (int, float)):
-        raise ValueError("Risk parameter must be a number")
     if value <= 0 or value > 1:
-        raise ValueError("Risk parameter must be between 0 and 1")
+        raise ValidationError("Risk parameter must be between 0 and 1")
     return float(value)
 
 
 def sanitize_input(value: str) -> str:
     if not isinstance(value, str):
-        raise ValueError("Input must be a string")
+        raise ValidationError("Input must be a string")
     return value.replace(";", "").replace("--", "").strip()


### PR DESCRIPTION
## Summary
- implement decimal-based financial validator
- add validation wrappers using the new validator
- test validator logic

## Testing
- `pytest tests/test_financial_validator.py -q`
- `pytest tests/ --cov=src/ --cov-report=html` *(fails: 29 errors during collection)*
- `mypy src/ --strict` *(fails: found 164 errors)*
- `bandit -r src/`

------
https://chatgpt.com/codex/tasks/task_e_6846eb73df7c8322b76c7fea1d4c5dfe