### PR TITLE
Implement ML-based risk monitoring

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ psutil==5.9.8
 fakeredis==2.23.2
 pydantic==2.7.1
 mypy==1.10.0
+scikit-learn==1.4.2
 numba==0.61.2  # Pinned version
 prometheus_client==0.20.0
 aiohttp==3.9.5

--- a/src/risk/__init__.py
+++ b/src/risk/__init__.py
@@ -5,6 +5,7 @@ from .advanced_circuit_breaker import (
     CircuitBreakerMonitor,
     RateLimitError,
 )
+from .risk_monitor import RiskMonitor, RiskMonitorError
 from .kill_switch import KillSwitch, KillSwitchError
 from .risk_calculator import RiskCalculator
 from .compliance_monitor import ComplianceMonitor, ComplianceViolation, Trade
@@ -26,4 +27,6 @@ __all__ = [
     "CircuitBreakerRegistry",
     "CircuitBreakerMonitor",
     "RateLimitError",
+    "RiskMonitor",
+    "RiskMonitorError",
 ]

--- a/src/risk/risk_monitor.py
+++ b/src/risk/risk_monitor.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import asyncio
+from typing import List
+
+import numpy as np
+from pydantic import BaseModel, Field
+from sklearn.ensemble import IsolationForest
+
+
+class RiskMonitorError(Exception):
+    """Raised when risk monitoring fails."""
+
+
+class RiskEvent(BaseModel):
+    position_value: float = Field(..., ge=0)
+    trade_volume: float = Field(..., ge=0)
+    pnl: float
+
+
+class RiskMonitor:
+    def __init__(self, window_size: int = 100) -> None:
+        if window_size <= 0:
+            raise ValueError("window_size must be positive")
+        self.window_size = window_size
+        self._data: List[list[float]] = []
+        self._model = IsolationForest(contamination=0.05, random_state=42)
+        self._lock = asyncio.Lock()
+
+    async def record_event(self, event: RiskEvent) -> None:
+        async with self._lock:
+            self._data.append([event.position_value, event.trade_volume, event.pnl])
+            if len(self._data) > self.window_size:
+                self._data.pop(0)
+
+    async def detect_anomaly(self) -> bool:
+        async with self._lock:
+            if len(self._data) < 10:
+                return False
+            data = np.asarray(self._data, dtype=float)
+            try:
+                self._model.fit(data)
+                result = self._model.predict(data[-1:].reshape(1, -1))
+                return bool(result[0] == -1)
+            except Exception as exc:
+                raise RiskMonitorError("anomaly detection failed") from exc

--- a/tests/risk/test_risk_monitor.py
+++ b/tests/risk/test_risk_monitor.py
@@ -1,0 +1,13 @@
+import pytest
+
+from src.risk.risk_monitor import RiskMonitor, RiskEvent
+
+
+@pytest.mark.asyncio
+async def test_anomaly_detection() -> None:
+    monitor = RiskMonitor(window_size=20)
+    for _ in range(15):
+        await monitor.record_event(RiskEvent(position_value=1000, trade_volume=10, pnl=0.01))
+    assert not await monitor.detect_anomaly()
+    await monitor.record_event(RiskEvent(position_value=1_000_000, trade_volume=10, pnl=0.01))
+    assert await monitor.detect_anomaly()


### PR DESCRIPTION
## Summary
- add a RiskMonitor using IsolationForest to detect anomalies
- expose RiskMonitor from risk package
- depend on scikit-learn
- test anomaly detection logic

## Testing
- `pytest tests/risk/test_risk_monitor.py -q`
- `pytest tests/ --cov=src/ --cov-report=html` *(fails: 27 errors during collection)*
- `mypy src/ --strict` *(fails: Found 183 errors)*
- `bandit -r src/`
- `python scripts/benchmark.py` *(fails: file not found)*

------
https://chatgpt.com/codex/tasks/task_e_684720b1a51483228508f77a8c319024